### PR TITLE
Add HomePedia PoC with map and sentiment analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,22 @@ Lancer l'application interactive :
 ```bash
 streamlit run app/streamlit_app.py
 ```
+
+## HomePedia PoC
+
+Ce prototype propose une exploration rapide du marché immobilier à Lyon.
+
+### Lancer l'application principale
+
+```bash
+streamlit run main.py
+```
+
+### Détails des fichiers
+
+- `main.py` : application Streamlit qui affiche une carte, les données et l'analyse de sentiment.
+- `generate_map.py` : fonctions pour créer la carte Folium.
+- `sentiment_analysis.py` : charge les commentaires, calcule un score moyen et génère un wordcloud.
+- `spark/process_prices.py` : exemple de script Spark pour résumer les prix.
+- `data/lyon_prices.csv` : données factices de prix au m².
+- `data/lyon_comments.json` : quelques commentaires factices.

--- a/data/lyon_comments.json
+++ b/data/lyon_comments.json
@@ -1,0 +1,5 @@
+[
+  {"comment": "Appartement charmant."},
+  {"comment": "Trop cher pour la taille."},
+  {"comment": "Bonne localisation mais besoins de travaux."}
+]

--- a/data/lyon_prices.csv
+++ b/data/lyon_prices.csv
@@ -1,0 +1,4 @@
+quartier,prix_m2,lat,lon
+Vieux Lyon,7500,45.762,4.827
+Presqu'Ile,8200,45.764,4.835
+Part-Dieu,6500,45.760,4.86

--- a/generate_map.py
+++ b/generate_map.py
@@ -1,0 +1,19 @@
+"""Fonctions pour générer une carte Folium."""
+
+import folium
+import pandas as pd
+
+
+def generate_price_map(df: pd.DataFrame) -> folium.Map:
+    """Génère une carte avec des cercles proportionnels aux prix."""
+    m = folium.Map(location=[45.75, 4.85], zoom_start=12)
+    for _, row in df.iterrows():
+        folium.CircleMarker(
+            location=[row["lat"], row["lon"]],
+            radius=5,
+            fill=True,
+            color="blue",
+            fill_color="blue",
+            popup=f"{row['quartier']} - {row['prix_m2']} €/m²",
+        ).add_to(m)
+    return m

--- a/main.py
+++ b/main.py
@@ -1,0 +1,55 @@
+"""Application Streamlit HomePedia."""
+
+import json
+import pandas as pd
+import streamlit as st
+from streamlit_folium import st_folium
+import matplotlib.pyplot as plt
+
+from generate_map import generate_price_map
+from sentiment_analysis import analyze_comments
+
+
+PRICES_PATH = "data/lyon_prices.csv"
+COMMENTS_PATH = "data/lyon_comments.json"
+
+
+def load_prices():
+    return pd.read_csv(PRICES_PATH)
+
+
+def main():
+    st.title("HomePedia - Marché immobilier à Lyon")
+
+    df = load_prices()
+
+    st.sidebar.header("Filtres")
+    quartiers = st.sidebar.multiselect(
+        "Quartiers", options=df["quartier"].unique().tolist(), default=list(df["quartier"].unique())
+    )
+    min_p, max_p = int(df.prix_m2.min()), int(df.prix_m2.max())
+    price_min, price_max = st.sidebar.slider(
+        "Prix au m²", min_p, max_p, (min_p, max_p)
+    )
+
+    filtered = df[df["quartier"].isin(quartiers)]
+    filtered = filtered[(filtered.prix_m2 >= price_min) & (filtered.prix_m2 <= price_max)]
+
+    st.subheader("Carte des prix")
+    fmap = generate_price_map(filtered)
+    st_folium(fmap, width=700, height=500)
+
+    st.subheader("Données")
+    st.dataframe(filtered)
+
+    st.subheader("Analyse de sentiment des commentaires")
+    score, wc = analyze_comments(COMMENTS_PATH)
+    st.write("Score moyen :", round(score, 2))
+    fig, ax = plt.subplots()
+    ax.imshow(wc)
+    ax.axis("off")
+    st.pyplot(fig)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,9 @@ pandas
 pyarrow
 streamlit
 requests
+textblob
+wordcloud
+matplotlib
+folium
+streamlit-folium
+pyspark

--- a/sentiment_analysis.py
+++ b/sentiment_analysis.py
@@ -1,0 +1,24 @@
+"""Analyse de sentiment et génération de wordcloud."""
+
+import json
+from textblob import TextBlob
+from wordcloud import WordCloud
+import matplotlib.pyplot as plt
+
+
+def analyze_comments(path: str):
+    """Renvoie le score de polarité moyen et un WordCloud."""
+    with open(path, "r", encoding="utf-8") as fh:
+        comments = [item["comment"] for item in json.load(fh)]
+    polarities = [TextBlob(c).sentiment.polarity for c in comments]
+    avg = sum(polarities) / len(polarities) if polarities else 0
+    wc = WordCloud(width=600, height=400).generate(" ".join(comments))
+    return avg, wc
+
+
+if __name__ == "__main__":
+    score, cloud = analyze_comments("data/lyon_comments.json")
+    print("Score moyen:", score)
+    plt.imshow(cloud)
+    plt.axis("off")
+    plt.show()

--- a/spark/process_prices.py
+++ b/spark/process_prices.py
@@ -1,0 +1,18 @@
+"""Traitement Spark des prix de Lyon."""
+
+from pyspark.sql import SparkSession
+
+
+def process_prices(input_path: str, output_path: str) -> None:
+    """Calcule la moyenne des prix et exporte un résumé."""
+    spark = SparkSession.builder.appName("ProcessPrices").getOrCreate()
+    df = spark.read.csv(input_path, header=True, inferSchema=True)
+    summary = df.groupBy().avg("prix_m2").withColumnRenamed(
+        "avg(prix_m2)", "prix_m2_moyen"
+    )
+    summary.coalesce(1).write.csv(output_path, header=True, mode="overwrite")
+    spark.stop()
+
+
+if __name__ == "__main__":
+    process_prices("data/lyon_prices.csv", "data/summary")


### PR DESCRIPTION
## Summary
- create example dataset for Lyon prices and comments
- add scripts for map generation and sentiment analysis
- add a small Spark job for processing prices
- create Streamlit `main.py` application demonstrating map, table and wordcloud
- document new PoC setup and update dependencies

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6853d23c7e6883259ec8a1265cc3939a